### PR TITLE
Fix unix socket issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
             - APP_NAME=DailyMotionTest 
         expose:
             - 8080
+        volumes:
+            - ./flask/socket:/app/socket
 
     nginx:
         build: ./nginx
@@ -16,3 +18,7 @@ services:
         restart: always
         ports:
             - "5000:5000"
+        volumes:
+            - ./flask/socket:/app/socket
+        depends_on:
+            - flask

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /app
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
-CMD ["uwsgi","uwsgi.ini"]
+CMD ["uwsgi", "--ini" ,"uwsgi.ini"]

--- a/flask/uwsgi.ini
+++ b/flask/uwsgi.ini
@@ -3,10 +3,8 @@
 ; module = wsgi
 wsgi-file = wsgi.py
 
-socket = :8080
+socket = /app/socket/web.sock
 chmod-socket = 666
 vacuum = true
 
 die-on-term = true
-
-

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -4,6 +4,6 @@ server {
 
     location / {
         include uwsgi_params;
-        uwsgi_pass dailymotion_flask:8080;
+        uwsgi_pass unix:///app/socket/web.sock;
     }
 }


### PR DESCRIPTION
Previously, we've been failed to communicate through unix socket.
So, we choose to port as alternation.
But, by using volume properly, unix socket communication has become possible.

`./flask/socket` is a host path and `/app/socket` is container path. So, for sharing socket file, we need to assign same path in host path.